### PR TITLE
Bump spring.security.version from 3.2.4.RELEASE to 5.3.3.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <!-- Shared version number properties -->
     <properties>
         <org.springframework.version>3.2.4.RELEASE</org.springframework.version>
-        <spring.security.version>3.2.4.RELEASE</spring.security.version>
+        <spring.security.version>5.3.3.RELEASE</spring.security.version>
         <tiles.version>2.2.2</tiles.version>
         <!-- If run from Bamboo this will be replaced with the bamboo build number -->
         <build.number>local</build.number>


### PR DESCRIPTION
Bumps `spring.security.version` from 3.2.4.RELEASE to 5.3.3.RELEASE.

Updates `spring-security-core` from 3.2.4.RELEASE to 5.3.3.RELEASE
- [Release notes](https://github.com/spring-projects/spring-security/releases)
- [Commits](https://github.com/spring-projects/spring-security/compare/3.2.4.RELEASE...5.3.3.RELEASE)

Updates `spring-security-config` from 3.2.4.RELEASE to 5.3.3.RELEASE
- [Release notes](https://github.com/spring-projects/spring-security/releases)
- [Commits](https://github.com/spring-projects/spring-security/compare/3.2.4.RELEASE...5.3.3.RELEASE)

Updates `spring-security-web` from 3.2.4.RELEASE to 5.3.3.RELEASE
- [Release notes](https://github.com/spring-projects/spring-security/releases)
- [Commits](https://github.com/spring-projects/spring-security/compare/3.2.4.RELEASE...5.3.3.RELEASE)

Signed-off-by: dependabot[bot] <support@github.com>