### PR TITLE
Bump org.springframework.version from 3.2.4.RELEASE to 5.2.7.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <!-- Shared version number properties -->
     <properties>
-        <org.springframework.version>3.2.4.RELEASE</org.springframework.version>
+        <org.springframework.version>5.2.7.RELEASE</org.springframework.version>
         <spring.security.version>3.2.4.RELEASE</spring.security.version>
         <tiles.version>2.2.2</tiles.version>
         <!-- If run from Bamboo this will be replaced with the bamboo build number -->


### PR DESCRIPTION
Bumps `org.springframework.version` from 3.2.4.RELEASE to 5.2.7.RELEASE.

Updates `spring-core` from 3.2.4.RELEASE to 5.2.7.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v3.2.4.RELEASE...v5.2.7.RELEASE)

Updates `spring-webmvc` from 3.2.4.RELEASE to 5.2.7.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v3.2.4.RELEASE...v5.2.7.RELEASE)

Signed-off-by: dependabot[bot] <support@github.com>