### PR TITLE
Bump commons-collections from 3.1 to 3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>commons-digester</groupId>


### PR DESCRIPTION
Bumps commons-collections from 3.1 to 3.2.2.

Signed-off-by: dependabot[bot] <support@github.com>